### PR TITLE
Add `best_id_score` to the schema consistently

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -71,7 +71,7 @@ The `.qms` folder will contain multiple metadata files that will be used to desc
 [[common-data-structures]]
 == Common data structures and formats
 
-We have some concepts that are common for some outputs and would be good to define and explain them here: 
+We have some concepts that are common for some outputs and would be good to define and explain them here:
 
 [[peptidoform]]
 === Peptidoform
@@ -784,7 +784,7 @@ The fields that are unique to the psm view are:
 | x
 
 | `consensus_support`
-| Consensus support for the given peptide spectrum match, when multiple search engines are used 
+| Consensus support for the given peptide spectrum match, when multiple search engines are used
 | float, null
 | -
 | -
@@ -792,15 +792,15 @@ The fields that are unique to the psm view are:
 | -
 
 | `number_peaks`
-| Number of peaks in the spectrum used for the peptide spectrum match 
+| Number of peaks in the spectrum used for the peptide spectrum match
 | int32, null
-| - 
+| -
 | -
 | -
 | -
 
 | `mz_array`
-| Array of m/z values for the spectrum used for the peptide spectrum match 
+| Array of m/z values for the spectrum used for the peptide spectrum match
 | array[float], null
 | -
 | -
@@ -808,7 +808,7 @@ The fields that are unique to the psm view are:
 | -
 
 | `intesity_array`
-| Array of intensity values for the spectrum used for the peptide spectrum match 
+| Array of intensity values for the spectrum used for the peptide spectrum match
 | array[float], null
 | -
 | -
@@ -989,7 +989,7 @@ Some of the fields are shared between the <<psm>> and <<feature>> views, they ca
 | *Field*
 | *Description*
 | *Type*
-|best_id_score     | The best search engine score from all the features/psms identified | double, null
+|best_id_score     | The best search engine score from all the features/psms identified | `[{"type": "record", "name": "score", "fields": [{ "name": "name", "type": "string" },{ "name": "value", "type": "float32" }]}, "null"]`
 |sample_accession  | The sample accession in the SDRF, which column is called `source name`  | string, null
 |abundance         | The peptide abundance in the given sample accession                     | float, null
 |===
@@ -1136,7 +1136,7 @@ The protein view is a report of the proteins identified/quantified in the experi
 
 | `abundance`              | Abundance of the given protein in the sample/experiment    | null, float
 | `sample_accession`       | Sample accession in the SDRF, which column is called `source name` | string
-| `best_id_score`           | The best search engine score for the identification      | string
+| `best_id_score`           | The best search engine score for the identification      | `[{"type": "record", "name": "score", "fields": [{ "name": "name", "type": "string" },{ "name": "value", "type": "float32" }]}, "null"]`
 | `gene_accessions`        | The gene accessions corresponding to every protein       | null, array[string]
 | `gene_names`             | The gene names corresponding to every protein            | null, array[string]
 | `number_peptides`        | The total number of peptides for a give protein        | null, integer

--- a/docs/feature.avsc
+++ b/docs/feature.avsc
@@ -12,9 +12,28 @@
 
 		{"name": "is_decoy", "type": "int", "doc": "Decoy indicator, 1 if the PSM is a decoy, 0 target"},
 		{"name": "calculated_mz", "type": "float32", "doc": "Theoretical peptide mass-to-charge ratio based on identified sequence and modifications"},
-		{"name": "additional_scores", "type": {"type": "array","items": { "type": "struct", "field": { "name": "string", "value": "float32"}}} ,
-		"doc": "List of structures, each structure contains two fields: name and value."},
-
+		{"name": "best_id_score", "type": ["null", {
+			"type": "record",
+			"name": "score",
+			"fields": [
+				{ "name": "name", "type": "string" },
+				{ "name": "value", "type": "float32" }
+			],
+			"doc": "A named score type and value representing an identification's measure of confidence or input feature"
+		}]},
+		{"name": "additional_scores", "type": ["null", {"type": "array",
+		"items": {
+			"type": "record",
+			"name": "score",
+			"fields": [
+				{"name": "name", "type": "string"},
+				{"name": "value", "type": "float32"}
+			],
+			"doc": "A named score type and value representing an identification's measure of confidence or input feature"
+		}
+		}],
+		"doc": "List of identification scores subsidiary to the best score"
+		},
 		{"name": "pg_accessions", "type": ["null", {"type": "array","items": "string"}], "doc": "Protein group accessions of all the proteins that the peptide maps to"},
 		{"name": "pg_positions", "type": ["null", {"type": "array","items": "string"}], "doc": "Protein start and end positions written as start_post:end_post"},
 		{"name": "unique", "type": ["null", "int"], "doc": "Unique peptide indicator, if the peptide maps to a single protein, the value is 1, otherwise 0"},

--- a/docs/peptide.avsc
+++ b/docs/peptide.avsc
@@ -33,9 +33,6 @@
 		},
 		{"name": "is_decoy", "type": "int", "doc": "Decoy indicator, 1 if the PSM is a decoy, 0 target"},
 		{"name": "calculated_mz", "type": "float32", "doc": "Theoretical peptide mass-to-charge ratio based on identified sequence and modifications"},
-		{"name": "additional_scores", "type": {"type": "array","items": { "type": "struct", "field": { "name": "string", "value": "float32"}}} ,
-		"doc": "List of structures, each structure contains two fields: name and value."},
-
 		{"name": "pg_accessions", "type": ["null",{"type": "array","items": "string"}], "doc": "Protein group accessions of all the proteins that the peptide maps to"},
 		{"name": "pg_positions", "type": ["null",{"type": "array","items": "string"}], "doc": "Protein start and end positions written as start_post:end_post"},
 		{"name": "unique", "type": ["null", "int"], "doc": "Unique peptide indicator, if the peptide maps to a single protein, the value is 1, otherwise 0"},

--- a/docs/peptide.avsc
+++ b/docs/peptide.avsc
@@ -9,7 +9,28 @@
 		"doc": "List of alternative site probabilities for the modification format: read the specification for more details"},
 		{"name": "posterior_error_probability", "type": ["null", "float32"], "doc": "Posterior error probability for the given peptide spectrum match"},
 		{"name": "global_qvalue", "type": ["null", "float32"], "doc": "Global q-value of the peptide or psm at the level of the experiment"},
-
+		{"name": "best_id_score", "type": ["null", {
+		"type": "record",
+		"name": "score",
+		"fields": [
+			{ "name": "name", "type": "string" },
+			{ "name": "value", "type": "float32" }
+		],
+		"doc": "A named score type and value representing an identification's measure of confidence or input feature"
+		}]},
+		{"name": "additional_scores", "type": ["null", {"type": "array",
+		"items": {
+			"type": "record",
+			"name": "score",
+			"fields": [
+				{"name": "name", "type": "string"},
+				{"name": "value", "type": "float32"}
+			],
+			"doc": "A named score type and value representing an identification's measure of confidence or input feature"
+		}
+		}],
+		"doc": "List of identification scores subsidiary to the best score"
+		},
 		{"name": "is_decoy", "type": "int", "doc": "Decoy indicator, 1 if the PSM is a decoy, 0 target"},
 		{"name": "calculated_mz", "type": "float32", "doc": "Theoretical peptide mass-to-charge ratio based on identified sequence and modifications"},
 		{"name": "additional_scores", "type": {"type": "array","items": { "type": "struct", "field": { "name": "string", "value": "float32"}}} ,

--- a/docs/protein.avsc
+++ b/docs/protein.avsc
@@ -20,6 +20,19 @@
 				"doc": "A named score type and value representing an identification's measure of confidence or input feature"
 			}
 		]},
+		{"name": "additional_scores", "type": ["null", {"type": "array",
+		"items": {
+			"type": "record",
+			"name": "score",
+			"fields": [
+				{"name": "name", "type": "string"},
+				{"name": "value", "type": "float32"}
+			],
+			"doc": "A named score type and value representing an identification's measure of confidence or input feature"
+		}
+		}],
+		"doc": "List of identification scores subsidiary to the best score"
+		},
 		{"name": "gg_accessions", "type": ["null", {"type": "array","items": "string"}], "doc": "The gene accessions corresponding to every protein"},
 		{"name": "gg_names", "type": ["null", {"type": "array","items": "string"}], "doc": "The gene names corresponding to every protein"},
 		{"name": "number_peptides","type": ["null", "int"], "doc": "The total number of peptides for a give protein"},

--- a/docs/protein.avsc
+++ b/docs/protein.avsc
@@ -8,7 +8,18 @@
 		{"name": "sample_accession", "type":  "string", "doc": "The sample accession in the SDRF, which column is called source name"},
 		{"name": "global_qvalue","type": ["null", "float32"], "doc": "The global qvalue for a given protein or protein groups"},
 		{"name": "is_decoy","type": ["null", "int"], "doc": "If the protein is decoy"},
-		{"name": "best_id_score", "type": "string", "doc": "The best search engine score for the identification"},
+		{"name": "best_id_score", "type": [
+			"null",
+			{
+				"type": "record",
+				"name": "score",
+				"fields": [
+					{ "name": "name", "type": "string" },
+					{ "name": "value", "type": "float32" }
+				],
+				"doc": "A named score type and value representing an identification's measure of confidence or input feature"
+			}
+		]},
 		{"name": "gg_accessions", "type": ["null", {"type": "array","items": "string"}], "doc": "The gene accessions corresponding to every protein"},
 		{"name": "gg_names", "type": ["null", {"type": "array","items": "string"}], "doc": "The gene names corresponding to every protein"},
 		{"name": "number_peptides","type": ["null", "int"], "doc": "The total number of peptides for a give protein"},

--- a/docs/psm.avsc
+++ b/docs/psm.avsc
@@ -12,7 +12,16 @@
 
     {"name": "is_decoy", "type": "int", "doc": "Decoy indicator, 1 if the PSM is a decoy, 0 target"},
     {"name": "calculated_mz", "type": "double", "doc": "Theoretical peptide mass-to-charge ratio based on identified sequence and modifications"},
-    {"name": "additional_scores", "type": ["null", {",type": "array",
+    {"name": "best_id_score", "type": ["null", {
+      "type": "record",
+      "name": "score",
+      "fields": [
+        { "name": "name", "type": "string" },
+        { "name": "value", "type": "float32" }
+      ],
+      "doc": "A named score type and value representing an identification's measure of confidence or input feature"
+    }]},
+    {"name": "additional_scores", "type": ["null", {"type": "array",
       "items": {
           "type": "record",
           "name": "score",
@@ -20,9 +29,10 @@
              {"name": "name", "type": "string"},
              {"name": "value", "type": "float32"}
           ],
+          "doc": "A named score type and value representing an identification's measure of confidence or input feature"
       }
      }],
-     "doc": "List of structures, each structure contains two fields: name and value."
+     "doc": "List of identification scores subsidiary to the best score"
     },
     {"name": "pg_accessions", "type": ["null",{"type": "array","items": "string"}], "doc": "Protein group accessions of all the proteins that the peptide maps to"},
     {"name": "pg_positions", "type": ["null",{"type": "array","items": "string"}], "doc": "Protein start and end positions written as start_post:end_post"},


### PR DESCRIPTION
### **User description**
Fixes #72


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Introduced a structured format for `best_id_score` across multiple schema files, enhancing consistency and clarity.
- Updated `additional_scores` to use a structured format, providing a more detailed representation of identification scores.
- Improved documentation by removing trailing spaces and ensuring consistent formatting.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.adoc</strong><dd><code>Update `best_id_score` type and clean up formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/README.adoc

<li>Updated the type for <code>best_id_score</code> to a structured format.<br> <li> Removed trailing spaces for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/73/files#diff-af3ef72d2f8bd1c682fddb4b4b91757e1965f8f47078a4198e6de160797312c1">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feature.avsc</strong><dd><code>Add structured `best_id_score` and update `additional_scores`</code></dd></summary>
<hr>

docs/feature.avsc

<li>Added <code>best_id_score</code> with a structured type.<br> <li> Updated <code>additional_scores</code> to a structured type.<br>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/73/files#diff-68a5ea89be3a1db989825f371c2d0830582f9e6481d70f871c5eae3a09a5a9c3">+22/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>peptide.avsc</strong><dd><code>Add structured `best_id_score` and update `additional_scores`</code></dd></summary>
<hr>

docs/peptide.avsc

<li>Added <code>best_id_score</code> with a structured type.<br> <li> Updated <code>additional_scores</code> to a structured type.<br>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/73/files#diff-c11417fd0306c5850faf7bcc85bc1acfab3bf276fdb7764156d455cdf0838f69">+22/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>protein.avsc</strong><dd><code>Update `best_id_score` to structured type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/protein.avsc

- Changed `best_id_score` to a structured type.



</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/73/files#diff-ef544bd8599a8d2d789e11f85d49aae0788ba6e9d45e319ee3253e71632ec7a5">+12/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>psm.avsc</strong><dd><code>Add structured `best_id_score` and update `additional_scores`</code></dd></summary>
<hr>

docs/psm.avsc

<li>Added <code>best_id_score</code> with a structured type.<br> <li> Updated <code>additional_scores</code> to a structured type.<br>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms.io/pull/73/files#diff-fa4d96c9c8c9b27d9b0d37ed5cc1c6a49ab4aefce00cdae2249c8e99bb7aae77">+12/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information