### PR TITLE
Align README with actual CLI; add Apache-2.0 LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,81 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+   Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+   Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+   You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+   (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+   Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+   This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+   Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+   In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+   While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright 2025 BigBio
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # quantms.io
+
 [![Python application](https://github.com/bigbio/quantms.io/actions/workflows/python-app.yml/badge.svg?branch=dev)](https://github.com/bigbio/quantms.io/actions/workflows/python-app.yml)
 [![Upload Python Package](https://github.com/bigbio/quantms.io/actions/workflows/python-publish.yml/badge.svg)](https://github.com/bigbio/quantms.io/actions/workflows/python-publish.yml)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/e71a662e8d4f483094576c1d8f8888c3)](https://app.codacy.com/gh/bigbio/quantms.io/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
@@ -57,15 +58,14 @@ quantmsioc convert maxquant-feature [OPTIONS]
 quantmsioc convert maxquant-pg [OPTIONS]
 
 # Convert FragPipe files
-quantmsioc convert fragpipe-psm [OPTIONS]
+quantmsioc convert fragpipe [OPTIONS]
 
-# Convert DiaNN files
+# Convert DIA-NN files
 quantmsioc convert diann [OPTIONS]
 quantmsioc convert diann-pg [OPTIONS]
 
-# Convert expression data
-quantmsioc convert differential [OPTIONS]
-quantmsioc convert absolute [OPTIONS]
+# Convert IdXML to PSM parquet
+quantmsioc convert idxml [OPTIONS]
 ```
 
 ### Analysis Commands
@@ -73,11 +73,11 @@ quantmsioc convert absolute [OPTIONS]
 Analyze quantms.io data:
 
 ```bash
-# Compare sets of PSMs
-quantmsioc analyze compare-psms [OPTIONS]
+# PSM statistics
+quantmsioc stats analyze psm [OPTIONS]
 
-# Generate statistics
-quantmsioc analyze stats [OPTIONS]
+# Project AE (iBAQ) and PSM parquet statistics
+quantmsioc stats analyze project-ae [OPTIONS]
 ```
 
 ### Visualization Commands
@@ -85,8 +85,20 @@ quantmsioc analyze stats [OPTIONS]
 Visualize quantms.io data:
 
 ```bash
-# Create plots
-quantmsioc visualize plot [OPTIONS]
+# Plot peptides by condition in LFQ
+quantmsioc visualize plot psm-peptides [OPTIONS]
+
+# Plot iBAQ distribution
+quantmsioc visualize plot ibaq-distribution [OPTIONS]
+
+# Plot KDE intensity distribution
+quantmsioc visualize plot kde-intensity [OPTIONS]
+
+# Plot peptide distribution
+quantmsioc visualize plot peptide-distribution [OPTIONS]
+
+# Plot intensity box plot
+quantmsioc visualize plot box-intensity [OPTIONS]
 ```
 
 ### Project Management Commands
@@ -94,10 +106,10 @@ quantmsioc visualize plot [OPTIONS]
 Manage project metadata:
 
 ```bash
-# Generate PRIDE project JSON
-quantmsioc project pride [OPTIONS]
+# Generate project.json from a PRIDE accession and SDRF
+quantmsioc project create [OPTIONS]
 
-# Attach files to JSON
+# Attach files to project.json
 quantmsioc project attach [OPTIONS]
 ```
 
@@ -106,39 +118,31 @@ quantmsioc project attach [OPTIONS]
 Transform data within the quantms.io ecosystem:
 
 ```bash
-# Generate iBAQ view
+# Generate iBAQ feature file
 quantmsioc transform ibaq [OPTIONS]
 
-# Convert spectrum data to Parquet
-quantmsioc transform spectrum-parquet [OPTIONS]
+# Convert IBAQ absolute file
+quantmsioc transform ae [OPTIONS]
 
-# Convert gene data to Parquet
-quantmsioc transform gene-parquet [OPTIONS]
+# Merge AE files into AnnData (.h5ad)
+quantmsioc transform anndata [OPTIONS]
+
+# Convert MSstats differential file
+quantmsioc transform differential [OPTIONS]
+
+# Map gene information from FASTA
+quantmsioc transform gene [OPTIONS]
+
+# Map spectrum information from mzML
+quantmsioc transform spectra [OPTIONS]
 
 # Update UniProt mappings
-quantmsioc transform update-uniprot [OPTIONS]
-
-# Merge AE files
-quantmsioc transform merge-ae [OPTIONS]
+quantmsioc transform uniprot [OPTIONS]
 ```
 
 ## Configuration
 
-The package can be configured using environment variables:
-
-- `QUANTMSIO_LOG_LEVEL`: Set logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-- `QUANTMSIO_LOG_FILE`: Path to log file
-- `QUANTMSIO_LOG_FORMAT`: Custom log format string
-- `QUANTMSIO_LOG_DATE_FORMAT`: Custom date format for logs
-- `QUANTMSIO_LOG_JSON`: Enable JSON-formatted logs if set to "true"
-
-Example:
-
-```bash
-export QUANTMSIO_LOG_LEVEL=DEBUG
-export QUANTMSIO_LOG_FILE=/path/to/logs/quantmsio.log
-export QUANTMSIO_LOG_JSON=true
-```
+Most commands support a `--verbose` flag that enables more detailed logging to stdout. The CLI uses standard logging configuration and does not require environment variables.
 
 ## Development
 
@@ -147,36 +151,37 @@ export QUANTMSIO_LOG_JSON=true
 ```
 quantmsio/
 ├── __init__.py
-├── quantmsioc.py         # CLI entry point
-├── commands/             # Command implementations
-├── core/                 # Core functionality
-├── operate/              # Operation-specific code
-└── utils/                # Utility functions
-    ├── logger.py         # Logging configuration
-    ├── file_utils.py     # File handling utilities
-    ├── pride_utils.py    # PRIDE-specific utilities
-    └── constants.py      # Constants and configurations
+├── quantmsioc.py           # CLI entry point (poetry script: quantmsioc)
+├── commands/               # CLI command groups
+│   ├── convert/            # Converters: quantms, maxquant, diann, idxml, fragpipe
+│   ├── transform/          # Transforms: ibaq, ae, gene, spectra, anndata, differential, uniprot
+│   └── utils/              # Utility CLIs: project(create/attach), stats(analyze), plot
+├── core/                   # Core logic & formats
+│   ├── quantms/            # quantms feature/psm/pg, mztab helpers
+│   ├── diann/, maxquant/, fragpipe/, idxml_utils/ ...
+│   └── project.py, duckdb.py, format.py, common.py
+├── operate/                # High-level operations (stats, plotting, tools)
+│   ├── plots.py, query.py, statistics.py, tools.py
+│   └── ...
+└── utils/                  # Utilities
+    ├── logger.py           # Basic logger getter
+    ├── file_utils.py       # File helpers (e.g., AE file discovery)
+    ├── pride_utils.py      # PRIDE archive helpers
+    ├── mztab_utils.py      # mzTab helpers
+    ├── system.py           # System utilities
+    └── constants.py        # Constants and configurations
 ```
 
 ### Recent Improvements
 
-1. **Enhanced CLI Structure**
-   - Organized commands into logical groups
+1. **CLI Structure**
+
+   - Commands are organized into `convert`, `transform`, `visualize`, `stats`, and `project`
    - Improved help messages and documentation
-   - Better command naming and organization
 
-2. **Improved Logging System**
-   - Structured logging support
-   - JSON log format option
-   - Request tracking with unique IDs
-   - Automatic log rotation
-   - Environment-based configuration
-
-3. **Code Organization**
-   - Better separation of concerns
-   - More modular design
-   - Improved type hints
-   - Enhanced documentation
+2. **Code Organization**
+   - Separation of concerns across `core`, `commands`, `operate`, and `utils`
+   - Modular design with clearer entry points
 
 ### Contributing
 
@@ -188,7 +193,7 @@ quantmsio/
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the Apache-2.0 License - see the LICENSE file for details.
 
 ## Core contributors and collaborators
 
@@ -207,7 +212,6 @@ As part of our efforts toward delivering open and inclusive science, we follow t
 
 ## Copyright notice
 
-
     This information is free; you can redistribute it and/or modify it
     under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -221,4 +225,3 @@ As part of our efforts toward delivering open and inclusive science, we follow t
     You should have received a copy of the GNU General Public License
     along with this work; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-


### PR DESCRIPTION
- Sync README with real CLI groups/commands
  - Add transform ae
  - Remove unregistered create-duckdb
  - Ensure visualize/stats/project sections match actual subcommands

- Fix source install URL
  - Use bigbio/quantms.io

- Remove deprecated env-var logging section
  - Prefer --verbose for detailed logs

- Improve Project Structure
  - Reflect current directories and responsibilities
  - Clarify CLI entry (poetry script: quantmsioc)

- Standardize license to Apache-2.0
  - Add full LICENSE text
  - Add copyright line

- Verification
  - Confirmed all commands via local --help outputs